### PR TITLE
dvc - 10427 Clean Environment Sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv/
+.python-version
 /model.tar.gz

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sources/dvc-task"]
+	path = sources/dvc-task
+	url = https://github.com/iterative/dvc-task

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "sources/dvc-task"]
 	path = sources/dvc-task
 	url = https://github.com/iterative/dvc-task
+[submodule "sources/dvc"]
+	path = sources/dvc
+	url = https://github.com/iterative/dvc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "sources/dvc-task"]
 	path = sources/dvc-task
-	url = https://github.com/iterative/dvc-task
+	url = git@github.com:nablabits/dvc-task.git
+	branch = feature/dvc-10427-add-delay-to-the-clean

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "sources/dvc-task"]
 	path = sources/dvc-task
 	url = https://github.com/iterative/dvc-task
-[submodule "sources/dvc"]
-	path = sources/dvc
-	url = https://github.com/iterative/dvc


### PR DESCRIPTION
Related to:

- https://github.com/iterative/dvc/issues/10427

This is just a clean environment where reviewers can check that the approach works as it takes some time to config it from the scratch. You will find more context in [this comment](https://github.com/iterative/dvc/issues/10427#issuecomment-2323211461) but below are the instructions to reproduce and verify the solution

## How to Test this
- Clone the repo
- Install deps
- Checkcout the branch. Make sure the submodules `dvc` & `dvc-task` are correctly imported

### Reproduce the Issue
- Queue a couple of experiments and run them
```shell
dvc exp run --queue --set-param "train.fine_tune_args.epochs=2,3" && \
dvc queue start -j 2 -v
```

- Give it some time to complete, you can check this with `tail .dvc/tmp/exps/celery/dvc-exp-worker-1.out`  if something like this appears, it means that they have finished:
```
[2024-09-05 08:05:31,883: INFO/MainProcess] done
2024-09-05 08:05:31,885 DEBUG: Analytics is enabled.
[2024-09-05 08:05:31,885: DEBUG/MainProcess] Analytics is enabled.
2024-09-05 08:05:31,986 DEBUG: Trying to spawn ['daemon', 'analytics', '/tmp/tmpol8kssna', '-v']
[2024-09-05 08:05:31,986: DEBUG/MainProcess] Trying to spawn ['daemon', 'analytics', '/tmp/tmpol8kssna', '-v']
2024-09-05 08:05:31,999 DEBUG: Spawned ['daemon', 'analytics', '/tmp/tmpol8kssna', '-v'] with pid 594310
[2024-09-05 08:05:31,999: DEBUG/MainProcess] Spawned ['daemon', 'analytics', '/tmp/tmpol8kssna', '-v'] with pid 594310
(example-experiments)
```

- Verify that a couple of files with this `body`  remain in `in`:

```shell
grep 'eyJtZXRob2QiOiAic2h1dGRvd24iLCAiYXJndW1lbnRzIjoge30sICJkZXN0aW5hdGlvbiI6IG51bGwsICJwYXR0ZXJuIjogbnVsbCwgIm1hdGNoZXIiOiBudWxsfQ==' \
.dvc/tmp/exps/celery/broker/in/*
```

### Verify the solution

- Override the default source for `dvc-task` that will contain the changes:

 ```shell
 export PYTHONPATH="`pwd`/sources/dvc-task/src"
 ```

- Clean everything from previous round and start over
```shell
dvc exp clean && dvc queue remove --all && \
rm -rf .dvc/cache/runs && \
echo '' > .dvc/tmp/exps/celery/*.out && \
dvc exp run --queue --set-param "train.fine_tune_args.epochs=2,3" && \
dvc queue start -j 2 -v
```

- Verify that no file with this `body`  remains in `in`:

```shell
grep 'eyJtZXRob2QiOiAic2h1dGRvd24iLCAiYXJndW1lbnRzIjoge30sICJkZXN0aW5hdGlvbiI6IG51bGwsICJwYXR0ZXJuIjogbnVsbCwgIm1hdGNoZXIiOiBudWxsfQ==' \
.dvc/tmp/exps/celery/broker/in/*
```